### PR TITLE
docker config fixes for web and api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,12 @@ services:
             - db
             - cache
         env_file: .env.local
+        environment:
+            - DJANGO_SETTINGS_MODULE=settings
         volumes:
             - api_uwsgispooler_dev:/var/uwsgispooler
             - api_uwsgilog_dev:/var/log/uwsgi/
-            - ./api:/app
+            - ./api:/app:cached
         ports:
             - 8081:8000
         command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
@@ -25,19 +27,19 @@ services:
             - cache
         env_file: .env.local
         volumes:
-            - ./apiv3:/app
+            - ./apiv3:/app:cached
         ports:
             - 8082:8000
         command: ["/start.sh"]
 
-    web-buscador:
-      image: node:9
-      ports:
-        - 8083:8080
-      command: bash -c "yarn && yarn serve"
-      working_dir: /src
-      volumes:
-        - "./web-buscador:/src"
+    # web-buscador:
+    #     image: node:9
+    #     ports:
+    #         - 8083:8080
+    #     command: bash -c "yarn && yarn serve"
+    #     working_dir: /src
+    #     volumes:
+    #         - "./web-buscador:/src"
 
     web:
         build: ./web
@@ -45,12 +47,14 @@ services:
             - db
             - cache
         env_file: .env.local
+        environment:
+            - DJANGO_SETTINGS_MODULE=settings
         volumes:
             - web_uwsgispooler_dev:/var/uwsgispooler
             - web_uwsgilog_dev:/var/log/uwsgi/
             - web_static:/static
             - web_media:/media
-            - ./web:/app
+            - ./web:/app:cached
         ports:
             - 8080:8000
         command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,14 +32,14 @@ services:
             - 8082:8000
         command: ["/start.sh"]
 
-    # web-buscador:
-    #     image: node:9
-    #     ports:
-    #         - 8083:8080
-    #     command: bash -c "yarn && yarn serve"
-    #     working_dir: /src
-    #     volumes:
-    #         - "./web-buscador:/src"
+    web-buscador:
+        image: node:9
+        ports:
+            - 8083:8080
+        command: bash -c "yarn && yarn serve"
+        working_dir: /src
+        volumes:
+            - ./web-buscador:/src
 
     web:
         build: ./web


### PR DESCRIPTION
Fixes para los containers de `web` y `api` , estaba tomando del .env el DJANGO_SETTINGS_MODULE de `apiv3`. Tendriamos que tener .envs distintos para cada servicio

El `:cached` en los volumenes es un fix para un bug de docker https://github.com/docker/for-mac/issues/1759 que evita un uso elevado de cpu constante en mac

El container de `web-buscador` tiene una performance bastante baja, comparado con correrlo local, habria que ver si se puede solucionar o si conviene directamente tener esto por separado en desarroll